### PR TITLE
fastq_summ_F0x200

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 LIST OF CHANGES
 
+  - add "-F 0x 200" flag to fastq_summ command to filter qc fails from 10k read fastq subsets used for (some) QC checks
+
 release 50.12
   - seqchksum_merge.pl
       updated to generate chksums on the fly is given a bam file

--- a/lib/npg_common/extractor/fastq.pm
+++ b/lib/npg_common/extractor/fastq.pm
@@ -304,7 +304,7 @@ sub generate_cache {
     if($from->[0] =~ /\.bam$/smx) {
 		foreach my $file (@{$from}) {
 			my ($outbase,$dir,$suffix) = fileparse $file, '.bam';
-			my $cmd = "fastq_summ -s $sample_size -k -o ${outbase} -d $cache $file";
+			my $cmd = "fastq_summ -F 0x200 -s $sample_size -k -o ${outbase} -d $cache $file";
 			if(system $cmd) {
 				croak qq[fastq_summ failed for file: $file, cmd: $cmd: $CHILD_ERROR];
 			}


### PR DESCRIPTION
add "-F 0x200" flag to fastq_summ command to filter qc fails from 10k subset fastq files for QC