### PR TITLE
perl critic issue fix

### DIFF
--- a/bin/seqchksum_merge.pl
+++ b/bin/seqchksum_merge.pl
@@ -173,7 +173,7 @@ sub initialise_outrows {
 	# convert non-comment rows into arrays
 	$init_rows = [ map { /^\#/smx ?  $_ :[ split /\t/smx ]} @{$inrows} ];
         # convert non-comment rows into arrays
-	$init_rows = [ map { $_ !~ /^\#/smx? [ (split /\t/smx, $_) ]: $_; } @{$inrows} ];
+	$init_rows = [ map { /^\#/smx ? $_ : [ (split /\t/smx) ] } @{$inrows} ];
 	if(not @{$init_rows}) {
 		croak q[No input in initial input file ], $fn;
 	}


### PR DESCRIPTION
Failed test 'Test::Perl::Critic for "blib/script/seqchksum_merge.pl"'
at /local/scratch01/npg_jenkins/workspace/builds/14/lib/perl5/Test/Perl/Critic.pm line 104.
Useless use of $_ at blib/script/seqchksum_merge.pl line 176, policy RegularExpressions::ProhibitUselessTopic
Useless use of $_ at blib/script/seqchksum_merge.pl line 176, policy BuiltinFunctions::ProhibitUselessTopic

when run as a part of deployment test in Jenkins