### PR TITLE
minimap indexes: use -x sr

### DIFF
--- a/bin/Ref_Maker
+++ b/bin/Ref_Maker
@@ -83,7 +83,7 @@ sub main { ##no critic (Subroutines::ProhibitExcessComplexity)
     $arguments{'bowtie2'}  = "-build $files[0] $files[0]";
     $arguments{'bwa0_6'}   = " index -p $files[0] -a $bwa_algorithm $files[0]";
     $arguments{'maq'}      = " fasta2bfa $files[0] $files[0].bfa";
-    $arguments{'minimap2'} = " -d $files[0].mmi $files[0]";
+    $arguments{'minimap2'} = " -x sr -d $files[0].mmi $files[0]";
     $arguments{'samtools'} = " faidx $files[0]";
     $arguments{'star'}     = " --runMode genomeGenerate --genomeDir ./ --genomeFastaFiles ../fasta/$files[0]";
 

--- a/t/10-refmaker.t
+++ b/t/10-refmaker.t
@@ -58,7 +58,7 @@ SKIP: {
     'bwa0_6/E-coli-K12.fa.sa' => '6e5b71027ce8766ce5e2eea08d1da0ec',
     'fasta/E-coli-K12.fa' => '7285062348a4cb07a23fcd3b44ffcf5d',
     'fasta/E-coli-K12.fa.fai' => '3bfb02378761ec6fe2b57e7dc99bd2b5',
-    'minimap2/E-coli-K12.fa.mmi' => '57c2841e5d5507e77a71d27d99937be0',
+    'minimap2/E-coli-K12.fa.mmi' => '49365b9e6b379c469a7b57390f8b9512',
     'samtools/E-coli-K12.fa.fai' => '3bfb02378761ec6fe2b57e7dc99bd2b5',
     'star/chrLength.txt' => '9be57bfb0f37bd0c34ce8c3b58c62f0e',
     'star/chrNameLength.txt' => 'f67cb9999741fd15db9fa7a111c9008f',


### PR DESCRIPTION
when building minimap2 indexes, use "-x sr" to get default settings for short reads